### PR TITLE
fix ESLint style errors on build.ts (vite & webpack)

### DIFF
--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,7 +72,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.() + '\n'))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.()))}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,7 +72,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage.path))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages.map(vuePressPage => vuePressPage.path)) + '\n'}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -75,20 +75,25 @@ export const build = async (
     if (spinner) spinner.text = `Starting to render pages`
 
     // pre-render pages to html files
-    await Promise.all(app.pages?.map((page) => renderPage({
-      app,
-      page,
-      vueApp,
-      vueRouter,
-      renderToString,
-      ssrTemplate,
-      output: clientOutput.output,
-      outputEntryChunk: clientEntryChunk,
-      outputCssAsset: clientCssAsset,
-    })))
+    await Promise.all(
+      app.pages?.map((page) =>
+        renderPage({
+          app,
+          page,
+          vueApp,
+          vueRouter,
+          renderToString,
+          ssrTemplate,
+          output: clientOutput.output,
+          outputEntryChunk: clientEntryChunk,
+          outputCssAsset: clientCssAsset,
+        })
+      )
+    )
   })
 
-  if (spinner) spinner.text = `Successfully rendered ${app.pages.length} number of pages !!!`
+  if (spinner)
+    spinner.text = `Successfully rendered ${app.pages.length} number of pages !!!`
 
   // keep the server bundle files in debug mode
   if (!app.env.isDebug) {

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,7 +72,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.()))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.path))}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,7 +72,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages.map(vuePressPage => vuePressPage.path)) + '\n'}`
+    if (spinner) spinner.text = `Starting to render pages`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({
@@ -87,6 +87,8 @@ export const build = async (
       outputCssAsset: clientCssAsset,
     })))
   })
+
+  if (spinner) spinner.text = `Successfully rendered ${app.pages.length} number of pages !!!`
 
   // keep the server bundle files in debug mode
   if (!app.env.isDebug) {

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,21 +72,20 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.() + '\n'))}`
+
     // pre-render pages to html files
-    for (const page of app.pages) {
-      if (spinner) spinner.text = `Rendering pages ${chalk.magenta(page.path)}`
-      await renderPage({
-        app,
-        page,
-        vueApp,
-        vueRouter,
-        renderToString,
-        ssrTemplate,
-        output: clientOutput.output,
-        outputEntryChunk: clientEntryChunk,
-        outputCssAsset: clientCssAsset,
-      })
-    }
+    await Promise.all(app.pages?.map((page) => renderPage({
+      app,
+      page,
+      vueApp,
+      vueRouter,
+      renderToString,
+      ssrTemplate,
+      output: clientOutput.output,
+      outputEntryChunk: clientEntryChunk,
+      outputCssAsset: clientCssAsset,
+    })))
   })
 
   // keep the server bundle files in debug mode

--- a/packages/bundler-vite/src/build/build.ts
+++ b/packages/bundler-vite/src/build/build.ts
@@ -72,7 +72,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.path))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage.path))}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -95,7 +95,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.()))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.path))}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => await renderPage({

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -98,7 +98,7 @@ export const build = async (
     if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.path))}`
 
     // pre-render pages to html files
-    await Promise.all(app.pages?.map((page) => await renderPage({
+    await Promise.all(app.pages?.map((page) => renderPage({
       app,
       page,
       vueApp,

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -95,24 +95,21 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.() + '\n'))}`
+
     // pre-render pages to html files
-    for (const page of app.pages) {
-      if (spinner) {
-        spinner.text = `Rendering pages ${chalk.magenta(page.path)}`
-      }
-      await renderPage({
-        app,
-        page,
-        vueApp,
-        vueRouter,
-        renderToString,
-        ssrTemplate,
-        allFilesMeta,
-        initialFilesMeta,
-        asyncFilesMeta,
-        moduleFilesMetaMap,
-      })
-    }
+    await Promise.all(app.pages?.map((page) => await renderPage({
+      app,
+      page,
+      vueApp,
+      vueRouter,
+      renderToString,
+      ssrTemplate,
+      allFilesMeta,
+      initialFilesMeta,
+      asyncFilesMeta,
+      moduleFilesMetaMap,
+    })))
   })
 
   // keep the server bundle files in debug mode

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -95,7 +95,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.path))}`
+    if (spinner) spinner.text = `Starting to render pages`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => renderPage({
@@ -111,6 +111,8 @@ export const build = async (
       moduleFilesMetaMap,
     })))
   })
+
+  if (spinner) spinner.text = `Successfully rendered ${app.pages?.length} number of pages !!!`
 
   // keep the server bundle files in debug mode
   if (!app.env.isDebug) {

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -95,7 +95,7 @@ export const build = async (
     const { app: vueApp, router: vueRouter } = await createVueApp()
     const { renderToString } = await import('vue/server-renderer')
 
-    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.() + '\n'))}`
+    if (spinner) spinner.text = `Starting to render pages ${chalk.magenta(app.pages?.map(vuePressPage => vuePressPage?.toString?.()))}`
 
     // pre-render pages to html files
     await Promise.all(app.pages?.map((page) => await renderPage({

--- a/packages/bundler-webpack/src/build/build.ts
+++ b/packages/bundler-webpack/src/build/build.ts
@@ -98,21 +98,26 @@ export const build = async (
     if (spinner) spinner.text = `Starting to render pages`
 
     // pre-render pages to html files
-    await Promise.all(app.pages?.map((page) => renderPage({
-      app,
-      page,
-      vueApp,
-      vueRouter,
-      renderToString,
-      ssrTemplate,
-      allFilesMeta,
-      initialFilesMeta,
-      asyncFilesMeta,
-      moduleFilesMetaMap,
-    })))
+    await Promise.all(
+      app.pages?.map((page) =>
+        renderPage({
+          app,
+          page,
+          vueApp,
+          vueRouter,
+          renderToString,
+          ssrTemplate,
+          allFilesMeta,
+          initialFilesMeta,
+          asyncFilesMeta,
+          moduleFilesMetaMap,
+        })
+      )
+    )
   })
 
-  if (spinner) spinner.text = `Successfully rendered ${app.pages?.length} number of pages !!!`
+  if (spinner)
+    spinner.text = `Successfully rendered ${app.pages?.length} number of pages !!!`
 
   // keep the server bundle files in debug mode
   if (!app.env.isDebug) {


### PR DESCRIPTION
I did run `eslint --fix --ext .cjs,.js,.ts,.vue .` for you to fix the **style** errors reported.

However there are still 6 ESLint errors that need to be resolved but I will not do that for you to avoid changing code logic accidentally:
```
/packages/bundler-vite/src/build/build.ts
   3:10  error  'chalk' is defined but never used  @typescript-eslint/no-unused-vars
  95:7   error  'spinner' is not defined           no-undef
  96:5   error  'spinner' is not defined           no-undef

/packages/bundler-webpack/src/build/build.ts
    4:3  error  'chalk' is defined but never used  @typescript-eslint/no-unused-vars
  119:7  error  'spinner' is not defined           no-undef
  120:5  error  'spinner' is not defined           no-undef

✖ 6 problems (6 errors, 0 warnings)
```